### PR TITLE
Updates for GNOME Shell 49 and improves logging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{js,ts,css}]
+indent_size = 4

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,7 @@
     "singleQuote": false,
     "jsxSingleQuote": false,
     "indent_style": "space",
-    "useTabs": false
+    "useTabs": false,
+    "printWidth": 120,
+    "bracketSameLine": true
 }
-

--- a/SettingsCenter@lauinger-clan.de/extension.js
+++ b/SettingsCenter@lauinger-clan.de/extension.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import Shell from "gi://Shell";
 import Gio from "gi://Gio";
 import GObject from "gi://GObject";

--- a/SettingsCenter@lauinger-clan.de/extension.js
+++ b/SettingsCenter@lauinger-clan.de/extension.js
@@ -45,7 +45,7 @@ const SettingsCenterMenuToggle = GObject.registerClass(
                 settingsItem.visible = Main.sessionMode.allowSettings;
                 this.menu._settingsActions[Me.uuid] = settingsItem;
             } catch (error) {
-                console.error(`Error in SettingsCenterMenuToggle constructor: ${error}`);
+                this.getLogger().error(`Error in SettingsCenterMenuToggle constructor: ${error}`);
             }
         }
 

--- a/SettingsCenter@lauinger-clan.de/extension.js
+++ b/SettingsCenter@lauinger-clan.de/extension.js
@@ -17,13 +17,14 @@ const SettingsCenterMenuToggle = GObject.registerClass(
     class SettingsCenterMenuToggle extends QuickSettings.QuickMenuToggle {
         constructor(Me) {
             const { _settings } = Me;
+            const labelmenu = _(_settings.get_string("label-menu"));
             super({
-                title: _(_settings.get_string("label-menu")),
+                title: labelmenu,
                 iconName: "preferences-other-symbolic",
                 toggleMode: true,
             });
 
-            this.menu.setHeader("preferences-other-symbolic", _(_settings.get_string("label-menu")), "");
+            this.menu.setHeader("preferences-other-symbolic", labelmenu, "");
 
             _settings.bind("show-systemindicator", this, "checked", Gio.SettingsBindFlags.DEFAULT);
 

--- a/SettingsCenter@lauinger-clan.de/extension.js
+++ b/SettingsCenter@lauinger-clan.de/extension.js
@@ -9,10 +9,7 @@ import * as Util from "resource:///org/gnome/shell/misc/util.js";
 import * as Menu_Items from "./menu_items.js";
 import { PopupAnimation } from "resource:///org/gnome/shell/ui/boxpointer.js";
 
-import {
-    Extension,
-    gettext as _,
-} from "resource:///org/gnome/shell/extensions/extension.js";
+import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
 
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
 
@@ -26,18 +23,9 @@ const SettingsCenterMenuToggle = GObject.registerClass(
                 toggleMode: true,
             });
 
-            this.menu.setHeader(
-                "preferences-other-symbolic",
-                _(_settings.get_string("label-menu")),
-                ""
-            );
+            this.menu.setHeader("preferences-other-symbolic", _(_settings.get_string("label-menu")), "");
 
-            _settings.bind(
-                "show-systemindicator",
-                this,
-                "checked",
-                Gio.SettingsBindFlags.DEFAULT
-            );
+            _settings.bind("show-systemindicator", this, "checked", Gio.SettingsBindFlags.DEFAULT);
 
             try {
                 const menuItems = new Menu_Items.MenuItems(_settings);
@@ -45,38 +33,28 @@ const SettingsCenterMenuToggle = GObject.registerClass(
 
                 if (this._items.length > 0) {
                     this._items.forEach((item, index) => {
-                        const menuItem = new PopupMenu.PopupMenuItem(
-                            _(item.label),
-                            0
-                        );
+                        const menuItem = new PopupMenu.PopupMenuItem(_(item.label), 0);
                         menuItem.connect("activate", () => this.launch(item));
                         this.menu.addMenuItem(menuItem, index);
                     });
                 }
 
                 this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                const settingsItem = this.menu.addAction(_("Settings"), () =>
-                    Me._openPreferences()
-                );
+                const settingsItem = this.menu.addAction(_("Settings"), () => Me._openPreferences());
 
                 settingsItem.visible = Main.sessionMode.allowSettings;
                 this.menu._settingsActions[Me.uuid] = settingsItem;
             } catch (error) {
-                console.error(
-                    `Error in SettingsCenterMenuToggle constructor: ${error}`
-                );
+                console.error(`Error in SettingsCenterMenuToggle constructor: ${error}`);
             }
         }
 
         launch(settingItem) {
             if (settingItem["cmd"].match(/.desktop$/)) {
-                let app = Shell.AppSystem.get_default().lookup_app(
-                    settingItem["cmd"]
-                );
+                let app = Shell.AppSystem.get_default().lookup_app(settingItem["cmd"]);
 
                 if (app !== null) app.activate();
-                else if (settingItem["cmd-alt"] !== null)
-                    Util.spawn([settingItem["cmd-alt"]]);
+                else if (settingItem["cmd-alt"] !== null) Util.spawn([settingItem["cmd-alt"]]);
             } else {
                 let cmdArray = settingItem["cmd"].split(" ");
                 Util.spawn(cmdArray);
@@ -94,9 +72,7 @@ const SettingsCenterIndicator = GObject.registerClass(
             // Create the icon for the indicator
             this._indicator = this._addIndicator();
             this._indicator.icon_name = "preferences-other-symbolic";
-            this._indicator.visible = _settings.get_boolean(
-                "show-systemindicator"
-            );
+            this._indicator.visible = _settings.get_boolean("show-systemindicator");
 
             // Create the toggle menu and associate it with the indicator, being
             // sure to destroy it along with the indicator
@@ -124,9 +100,7 @@ export default class SettingsCenter extends Extension {
     }
 
     _onParamChangedIndicator() {
-        this._indicator.setIndicatorVisible(
-            this._settings.get_boolean("show-systemindicator")
-        );
+        this._indicator.setIndicatorVisible(this._settings.get_boolean("show-systemindicator"));
     }
 
     _openPreferences() {
@@ -149,12 +123,7 @@ export default class SettingsCenter extends Extension {
         ];
 
         settingsToMonitor.forEach((setting) => {
-            this._settingSignals.push(
-                this._settings.connect(
-                    `changed::${setting.key}`,
-                    setting.callback
-                )
-            );
+            this._settingSignals.push(this._settings.connect(`changed::${setting.key}`, setting.callback));
         });
     }
 

--- a/SettingsCenter@lauinger-clan.de/menu_items.js
+++ b/SettingsCenter@lauinger-clan.de/menu_items.js
@@ -102,13 +102,13 @@ export const MenuItems = class MenuItems {
         let itemsArray = [];
 
         for (let indexItem in items) {
-            let itemDatas = items[indexItem].split(";");
+            let itemData = items[indexItem].split(";");
 
             let item = {
-                label: itemDatas[0],
-                cmd: itemDatas[1],
-                enable: itemDatas[2] === "1",
-                "cmd-alt": itemDatas[3],
+                label: itemData[0],
+                cmd: itemData[1],
+                enable: itemData[2] === "1",
+                "cmd-alt": itemData[3],
             };
 
             itemsArray.push(item);

--- a/SettingsCenter@lauinger-clan.de/menu_items.js
+++ b/SettingsCenter@lauinger-clan.de/menu_items.js
@@ -1,3 +1,5 @@
+"use strict";
+
 export const MenuItems = class MenuItems {
     constructor(settings) {
         this._settings = settings;

--- a/SettingsCenter@lauinger-clan.de/menu_items.js
+++ b/SettingsCenter@lauinger-clan.de/menu_items.js
@@ -46,10 +46,7 @@ export const MenuItems = class MenuItems {
     changeOrder(index, posRel) {
         let items = this.getItems();
 
-        if (
-            (posRel < 0 && index > 0) ||
-            (posRel > 0 && index < items.length - 1)
-        ) {
+        if ((posRel < 0 && index > 0) || (posRel > 0 && index < items.length - 1)) {
             let temp = items[index];
             items.splice(index, 1);
             items.splice(parseInt(index) + posRel, 0, temp);

--- a/SettingsCenter@lauinger-clan.de/metadata.json
+++ b/SettingsCenter@lauinger-clan.de/metadata.json
@@ -3,7 +3,7 @@
     "gettext-domain": "SettingsCenter",
     "name": "SettingsCenter",
     "original-author": "Xes, l300lvl",
-    "shell-version": ["47", "48"],
+    "shell-version": ["48", "49"],
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SettingsCenter",
     "uuid": "SettingsCenter@lauinger-clan.de",
     "settings-schema": "org.gnome.shell.extensions.SettingsCenter",
@@ -11,5 +11,5 @@
         "github": "ChrisLauinger77",
         "paypal": "ChrisLauinger"
     },
-    "version-name": "48.3"
+    "version-name": "49.0"
 }

--- a/SettingsCenter@lauinger-clan.de/prefs.js
+++ b/SettingsCenter@lauinger-clan.de/prefs.js
@@ -3,10 +3,7 @@ import Gio from "gi://Gio";
 import Adw from "gi://Adw";
 import GObject from "gi://GObject";
 import * as Menu_Items from "./menu_items.js";
-import {
-    ExtensionPreferences,
-    gettext as _,
-} from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
+import { ExtensionPreferences, gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
 const errorLog = (...args) => {
     console.error("[SettingsCenter]", "Error:", ...args);
@@ -87,11 +84,7 @@ export default class AdwPrefs extends ExtensionPreferences {
 
     _addCmd(menuItems, page2, label, cmd) {
         if (label.text.trim() === "" || cmd.text.trim() === "") {
-            console.log(
-                _("SettingsCenter") +
-                    " " +
-                    _("'Label' and 'Command' must be filled out !")
-            );
+            console.log(_("SettingsCenter") + " " + _("'Label' and 'Command' must be filled out !"));
             return;
         }
         menuItems.addItem(label.text, cmd.text);
@@ -116,10 +109,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         );
         dialog.add_response("cancel", _("Cancel"));
         dialog.add_response("delete", _("Delete"));
-        dialog.set_response_appearance(
-            "delete",
-            Adw.ResponseAppearance.DESTRUCTIVE
-        );
+        dialog.set_response_appearance("delete", Adw.ResponseAppearance.DESTRUCTIVE);
 
         dialog.connect("response", (self, response) => {
             if (response === "cancel") return;
@@ -138,10 +128,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         });
         buttonUp.set_icon_name("go-up-symbolic");
         if (indexItem > 0) {
-            buttonUp.connect(
-                "clicked",
-                this._changeOrder.bind(this, menuItems, page2, indexItem, -1)
-            );
+            buttonUp.connect("clicked", this._changeOrder.bind(this, menuItems, page2, indexItem, -1));
             buttonUp.set_sensitive(true);
         } else {
             buttonUp.set_sensitive(false);
@@ -156,10 +143,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         });
         buttonDown.set_icon_name("go-down-symbolic");
         if (indexItem < itemslen - 1) {
-            buttonDown.connect(
-                "clicked",
-                this._changeOrder.bind(this, menuItems, page2, indexItem, 1)
-            );
+            buttonDown.connect("clicked", this._changeOrder.bind(this, menuItems, page2, indexItem, 1));
             buttonDown.set_sensitive(true);
         } else {
             buttonDown.set_sensitive(false);
@@ -177,10 +161,7 @@ export default class AdwPrefs extends ExtensionPreferences {
                 margin_start: 10,
             });
             buttonDel.set_icon_name("user-trash-symbolic");
-            buttonDel.connect(
-                "clicked",
-                this._delCmd.bind(this, menuItems, page2, indexItem)
-            );
+            buttonDel.connect("clicked", this._delCmd.bind(this, menuItems, page2, indexItem));
         }
         return buttonDel;
     }
@@ -190,10 +171,7 @@ export default class AdwPrefs extends ExtensionPreferences {
             active: item["enable"],
             valign: Gtk.Align.CENTER,
         });
-        valueList.connect(
-            "notify::active",
-            this._changeEnable.bind(this, menuItems, indexItem, valueList)
-        );
+        valueList.connect("notify::active", this._changeEnable.bind(this, menuItems, indexItem, valueList));
         return valueList;
     }
 
@@ -214,19 +192,9 @@ export default class AdwPrefs extends ExtensionPreferences {
             adwrow.set_tooltip_text(item["cmd"]);
             group3.add(adwrow);
             const buttonUp = this._buttonUp(menuItems, page2, indexItem);
-            const buttonDown = this._buttonDown(
-                menuItems,
-                page2,
-                indexItem,
-                items.length
-            );
+            const buttonDown = this._buttonDown(menuItems, page2, indexItem, items.length);
             const valueList = this._valueList(menuItems, indexItem, item);
-            const buttonDel = this._buttonDel(
-                menuItems,
-                page2,
-                indexItem,
-                items.length
-            );
+            const buttonDel = this._buttonDel(menuItems, page2, indexItem, items.length);
             adwrow.add_suffix(valueList);
             adwrow.activatable_widget = valueList;
             adwrow.add_suffix(buttonUp);
@@ -281,12 +249,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         adwrow = new Adw.SwitchRow({ title: _("Show SystemIndicator") });
         adwrow.set_tooltip_text(_("Toggle to show systemindicator"));
         group1.add(adwrow);
-        window._settings.bind(
-            "show-systemindicator",
-            adwrow,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT
-        );
+        window._settings.bind("show-systemindicator", adwrow, "active", Gio.SettingsBindFlags.DEFAULT);
 
         // group2
         const group2 = Adw.PreferencesGroup.new();
@@ -299,9 +262,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         group2.add(valueLabelAdd);
 
         const valueCmdAdd = new Adw.EntryRow({ title: _("Command") });
-        valueCmdAdd.set_tooltip_text(
-            _("Name of .desktop file (MyApp.desktop) or name of command")
-        );
+        valueCmdAdd.set_tooltip_text(_("Name of .desktop file (MyApp.desktop) or name of command"));
         group2.add(valueCmdAdd);
 
         adwrow = new Adw.ActionRow({ title: "" });
@@ -310,9 +271,7 @@ export default class AdwPrefs extends ExtensionPreferences {
             label: _("Select app"),
             valign: Gtk.Align.CENTER,
         });
-        buttonfilechooser.set_tooltip_text(
-            _("Usually located in '/usr/share/applications'")
-        );
+        buttonfilechooser.set_tooltip_text(_("Usually located in '/usr/share/applications'"));
         adwrow.add_suffix(buttonfilechooser);
         adwrow.activatable_widget = buttonfilechooser;
 
@@ -335,19 +294,8 @@ export default class AdwPrefs extends ExtensionPreferences {
         page2.set_name("settingscenter_page2");
         page2.set_icon_name("preferences-other-symbolic");
 
-        buttonAdd.connect(
-            "clicked",
-            this._addCmd.bind(
-                this,
-                menuItems,
-                page2,
-                valueLabelAdd,
-                valueCmdAdd
-            )
-        );
-        buttonAdd.set_tooltip_text(
-            _("'Label' and 'Command' must be filled out !")
-        );
+        buttonAdd.connect("clicked", this._addCmd.bind(this, menuItems, page2, valueLabelAdd, valueCmdAdd));
+        buttonAdd.set_tooltip_text(_("'Label' and 'Command' must be filled out !"));
         adwrow.add_suffix(buttonAdd);
         adwrow.activatable_widget = buttonAdd;
         // group3

--- a/SettingsCenter@lauinger-clan.de/prefs.js
+++ b/SettingsCenter@lauinger-clan.de/prefs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import Gtk from "gi://Gtk";
 import Gio from "gi://Gio";
 import Adw from "gi://Adw";

--- a/SettingsCenter@lauinger-clan.de/prefs.js
+++ b/SettingsCenter@lauinger-clan.de/prefs.js
@@ -5,15 +5,6 @@ import GObject from "gi://GObject";
 import * as Menu_Items from "./menu_items.js";
 import { ExtensionPreferences, gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
-const errorLog = (...args) => {
-    console.error("[SettingsCenter]", "Error:", ...args);
-};
-
-const handleError = (error) => {
-    errorLog(error);
-    return null;
-};
-
 const AppChooser = GObject.registerClass(
     class AppChooser extends Adw.Window {
         constructor(params = {}) {
@@ -84,7 +75,7 @@ export default class AdwPrefs extends ExtensionPreferences {
 
     _addCmd(menuItems, page2, label, cmd) {
         if (label.text.trim() === "" || cmd.text.trim() === "") {
-            console.log(_("SettingsCenter") + " " + _("'Label' and 'Command' must be filled out !"));
+            this.getLogger().log(_("SettingsCenter") + " " + _("'Label' and 'Command' must be filled out !"));
             return;
         }
         menuItems.addItem(label.text, cmd.text);
@@ -204,7 +195,7 @@ export default class AdwPrefs extends ExtensionPreferences {
     }
 
     _getFilename(fullPath) {
-        console.log("_getFilename fullPath: " + fullPath);
+        this.getLogger().log("_getFilename fullPath: " + fullPath);
         return fullPath.replace(/^.*[\\/]/, "");
     }
 
@@ -276,6 +267,13 @@ export default class AdwPrefs extends ExtensionPreferences {
         adwrow.activatable_widget = buttonfilechooser;
 
         buttonfilechooser.connect("clicked", async () => {
+            const errorLog = (...args) => {
+                this.getLogger().error("Error:", ...args);
+            };
+            const handleError = (error) => {
+                errorLog(error);
+                return null;
+            };
             const appRow = await myAppChooser.showChooser().catch(handleError);
             if (appRow !== null) {
                 valueLabelAdd.set_text(appRow.title);

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 
-# glib-compile-schemas SettingsCenter\@lauinger-clan.de/schemas/
+extension="SettingsCenter@lauinger-clan.de"
+extensionfile=$extension".shell-extension.zip"
 
-cd SettingsCenter\@lauinger-clan.de
-gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=menu_items.js --extra-source=../LICENSE --force
-cd ..
+echo "Running $0 for $extension with arguments: $@"
 
 case "$1" in
   zip|pack)
+    cd $extension
+    gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=./lib --extra-source=./ui/ --extra-source=./icons/ --extra-source=../LICENSE --force
+    cd ..
     echo "Extension zip created ..."
     ;;
   install)
-    gnome-extensions install SettingsCenter\@lauinger-clan.de.shell-extension.zip --force
-    gnome-extensions enable SettingsCenter\@lauinger-clan.de
+    if [ ! -f $extensionfile ]; then
+      $0 zip
+    fi
+    gnome-extensions install $extensionfile --force
+    gnome-extensions enable $extension
+    echo "Extension zip installed ..."
     ;;
   upload)
-    gnome-extensions upload SettingsCenter\@lauinger-clan.de.shell-extension.zip
+    if [ ! -f $extensionfile ]; then
+      $0 zip
+    fi
+    gnome-extensions upload --user ChrisLauinger77 --password-file /mnt/2TB/dev/ego_password $extensionfile
     ;;
   *)
     echo "Usage: $0 {zip|pack|install|upload}"

--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,22 @@
 # glib-compile-schemas SettingsCenter\@lauinger-clan.de/schemas/
 
 cd SettingsCenter\@lauinger-clan.de
-gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=menu_items.js --extra-source=../LICENSE
+gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=menu_items.js --extra-source=../LICENSE --force
 cd ..
-mv SettingsCenter@lauinger-clan.de.shell-extension.zip SettingsCenter@lauinger-clan.de.zip
 
-if [ "$1" = "zip" ] || [ "$1" = "pack" ]; then
-   echo "Extension zip created ..."
-else
-   gnome-extensions install SettingsCenter\@lauinger-clan.de.zip --force
-   gnome-extensions enable SettingsCenter\@lauinger-clan.de
-fi
+case "$1" in
+  zip|pack)
+    echo "Extension zip created ..."
+    ;;
+  install)
+    gnome-extensions install SettingsCenter\@lauinger-clan.de.shell-extension.zip --force
+    gnome-extensions enable SettingsCenter\@lauinger-clan.de
+    ;;
+  upload)
+    gnome-extensions upload SettingsCenter\@lauinger-clan.de.shell-extension.zip
+    ;;
+  *)
+    echo "Usage: $0 {zip|pack|install|upload}"
+    exit 1
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=menu_items.js 
 cd ..
 mv SettingsCenter@lauinger-clan.de.shell-extension.zip SettingsCenter@lauinger-clan.de.zip
 
-if [ "$1" = "zip" ]; then
+if [ "$1" = "zip" ] || [ "$1" = "pack" ]; then
    echo "Extension zip created ..."
 else
    gnome-extensions install SettingsCenter\@lauinger-clan.de.zip --force

--- a/po/SettingsCenter.pot
+++ b/po/SettingsCenter.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-09 00:47+0100\n"
+"POT-Creation-Date: 2025-07-26 12:36+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,116 +17,117 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: SettingsCenter@lauinger-clan.de/extension.js:64
-#: SettingsCenter@lauinger-clan.de/prefs.js:189
+#: SettingsCenter@lauinger-clan.de/extension.js:43
+#: SettingsCenter@lauinger-clan.de/prefs.js:223
 msgid "Settings"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
-msgid "SettingsCenter"
+#: SettingsCenter@lauinger-clan.de/prefs.js:18
+msgid "Search..."
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:34
-#: SettingsCenter@lauinger-clan.de/prefs.js:298
-msgid "'Label' and 'Command' must be filled out !"
+#: SettingsCenter@lauinger-clan.de/prefs.js:30
+msgid "Select"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:55
-msgid "Delete entry"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:56
-msgid "Are you sure you want to delete the entry ?"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:58
-#: SettingsCenter@lauinger-clan.de/prefs.js:328
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
+#: SettingsCenter@lauinger-clan.de/prefs.js:116
 msgid "Cancel"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:59
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+msgid "SettingsCenter"
+msgstr ""
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+#: SettingsCenter@lauinger-clan.de/prefs.js:311
+msgid "'Label' and 'Command' must be filled out !"
+msgstr ""
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:113
+msgid "Delete entry"
+msgstr ""
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:114
+msgid "Are you sure you want to delete the entry ?"
+msgstr ""
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:77
+#: SettingsCenter@lauinger-clan.de/prefs.js:132
 msgid "Up"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:147
 msgid "Down"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:165
 msgid "Del"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:146
+#: SettingsCenter@lauinger-clan.de/prefs.js:189
 msgid "Menu Items"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:194
+#: SettingsCenter@lauinger-clan.de/prefs.js:228
+#: SettingsCenter@lauinger-clan.de/prefs.js:277
 msgid "Select app"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:205
+#: SettingsCenter@lauinger-clan.de/prefs.js:239
 msgid "Global"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:242
 msgid "Menu Label"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:217
+#: SettingsCenter@lauinger-clan.de/prefs.js:247
 msgid "Apply"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:225
+#: SettingsCenter@lauinger-clan.de/prefs.js:255
 msgid "Show SystemIndicator"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:226
+#: SettingsCenter@lauinger-clan.de/prefs.js:256
 #: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:16
 msgid "Toggle to show systemindicator"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:242
+#: SettingsCenter@lauinger-clan.de/prefs.js:262
 msgid "Add Menu"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:266
 msgid "Label"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:246
+#: SettingsCenter@lauinger-clan.de/prefs.js:267
 msgid "Label to show in menu"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:270
 msgid "Command"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:255
+#: SettingsCenter@lauinger-clan.de/prefs.js:271
 msgid "Name of .desktop file (MyApp.desktop) or name of command"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:267
-msgid "Select desktop file"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:271
+#: SettingsCenter@lauinger-clan.de/prefs.js:280
 msgid "Usually located in '/usr/share/applications'"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:285
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 msgid "Add"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:290
+#: SettingsCenter@lauinger-clan.de/prefs.js:306
 msgid "Settings Center"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:325
-msgid "Select"
 msgstr ""
 
 #: SettingsCenter@lauinger-clan.de/translation.js:7
@@ -171,8 +172,4 @@ msgstr ""
 
 #: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:17
 msgid "Makes the systemindicator show/hide"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:21
-msgid "Last chosen file"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-09 00:47+0100\n"
-"PO-Revision-Date: 2024-03-09 00:48+0100\n"
+"POT-Creation-Date: 2025-07-26 12:36+0200\n"
+"PO-Revision-Date: 2025-07-26 12:36+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -16,119 +16,120 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Poedit 3.6\n"
 
-#: SettingsCenter@lauinger-clan.de/extension.js:64
-#: SettingsCenter@lauinger-clan.de/prefs.js:189
+#: SettingsCenter@lauinger-clan.de/extension.js:43
+#: SettingsCenter@lauinger-clan.de/prefs.js:223
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
-msgid "SettingsCenter"
-msgstr "Einstellungszentrum"
+#: SettingsCenter@lauinger-clan.de/prefs.js:18
+msgid "Search..."
+msgstr "Suchen..."
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:34
-#: SettingsCenter@lauinger-clan.de/prefs.js:298
-msgid "'Label' and 'Command' must be filled out !"
-msgstr "'Beschriftung' und 'Kommando' müssen ausgefüllt werden !"
+#: SettingsCenter@lauinger-clan.de/prefs.js:30
+msgid "Select"
+msgstr "Auswählen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:55
-msgid "Delete entry"
-msgstr "Eintrag löschen"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:56
-msgid "Are you sure you want to delete the entry ?"
-msgstr "Sind Sie sicher das Sie den Eintrag löschen möchten ?"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:58
-#: SettingsCenter@lauinger-clan.de/prefs.js:328
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
+#: SettingsCenter@lauinger-clan.de/prefs.js:116
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:59
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+msgid "SettingsCenter"
+msgstr "Einstellungszentrum"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+#: SettingsCenter@lauinger-clan.de/prefs.js:311
+msgid "'Label' and 'Command' must be filled out !"
+msgstr "'Beschriftung' und 'Kommando' müssen ausgefüllt werden !"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:113
+msgid "Delete entry"
+msgstr "Eintrag löschen"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:114
+msgid "Are you sure you want to delete the entry ?"
+msgstr "Sind Sie sicher das Sie den Eintrag löschen möchten ?"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete"
 msgstr "Löschen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:77
+#: SettingsCenter@lauinger-clan.de/prefs.js:132
 msgid "Up"
 msgstr "Auf"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:147
 msgid "Down"
 msgstr "Ab"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:165
 msgid "Del"
 msgstr "Entf"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:146
+#: SettingsCenter@lauinger-clan.de/prefs.js:189
 msgid "Menu Items"
 msgstr "Menü Einträge"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:194
+#: SettingsCenter@lauinger-clan.de/prefs.js:228
+#: SettingsCenter@lauinger-clan.de/prefs.js:277
 msgid "Select app"
 msgstr "App auswählen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:205
+#: SettingsCenter@lauinger-clan.de/prefs.js:239
 msgid "Global"
 msgstr "Global"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:242
 msgid "Menu Label"
 msgstr "Menü Beschriftung"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:217
+#: SettingsCenter@lauinger-clan.de/prefs.js:247
 msgid "Apply"
 msgstr "Übernehmen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:225
+#: SettingsCenter@lauinger-clan.de/prefs.js:255
 msgid "Show SystemIndicator"
 msgstr "Systemindikator anzeigen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:226
+#: SettingsCenter@lauinger-clan.de/prefs.js:256
 #: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:16
 msgid "Toggle to show systemindicator"
 msgstr "Umschalten der Anzeige des Systemindikators"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:242
+#: SettingsCenter@lauinger-clan.de/prefs.js:262
 msgid "Add Menu"
 msgstr "Menü hinzufügen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:266
 msgid "Label"
 msgstr "Beschriftung"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:246
+#: SettingsCenter@lauinger-clan.de/prefs.js:267
 msgid "Label to show in menu"
 msgstr "Beschriftung die im Menü angezeigt wird"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:270
 msgid "Command"
 msgstr "Kommando"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:255
+#: SettingsCenter@lauinger-clan.de/prefs.js:271
 msgid "Name of .desktop file (MyApp.desktop) or name of command"
 msgstr "Name der .desktop Datei (MyApp.desktop) oder Name des Befehls"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:267
-msgid "Select desktop file"
-msgstr "Desktop Datei auswählen"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:271
+#: SettingsCenter@lauinger-clan.de/prefs.js:280
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Befinden sich normalerweise in '/usr/share/applications'"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:285
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:290
+#: SettingsCenter@lauinger-clan.de/prefs.js:306
 msgid "Settings Center"
 msgstr "Einstellungszentrum"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:325
-msgid "Select"
-msgstr "Auswählen"
 
 #: SettingsCenter@lauinger-clan.de/translation.js:7
 msgid "Gnome Tweaks"
@@ -174,9 +175,11 @@ msgstr "Menü Einträge"
 msgid "Makes the systemindicator show/hide"
 msgstr "Systemindikator anzeigen/verstecken"
 
-#: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:21
-msgid "Last chosen file"
-msgstr "Letzt gewählte Datei"
+#~ msgid "Select desktop file"
+#~ msgstr "Desktop Datei auswählen"
+
+#~ msgid "Last chosen file"
+#~ msgstr "Letzt gewählte Datei"
 
 #~ msgid "..."
 #~ msgstr "..."

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-09 00:47+0100\n"
+"POT-Creation-Date: 2025-07-26 12:36+0200\n"
 "PO-Revision-Date: 2025-02-09 18:55+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,117 +18,118 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: SettingsCenter@lauinger-clan.de/extension.js:64
-#: SettingsCenter@lauinger-clan.de/prefs.js:189
+#: SettingsCenter@lauinger-clan.de/extension.js:43
+#: SettingsCenter@lauinger-clan.de/prefs.js:223
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
-msgid "SettingsCenter"
-msgstr "Centro de Configuraciones"
+#: SettingsCenter@lauinger-clan.de/prefs.js:18
+msgid "Search..."
+msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:34
-#: SettingsCenter@lauinger-clan.de/prefs.js:298
-msgid "'Label' and 'Command' must be filled out !"
-msgstr "¡'Etiqueta' y 'Comando' deben ser completados!"
+#: SettingsCenter@lauinger-clan.de/prefs.js:30
+msgid "Select"
+msgstr "Seleccionar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:55
-msgid "Delete entry"
-msgstr "Eliminar entrada"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:56
-msgid "Are you sure you want to delete the entry ?"
-msgstr "¿Está seguro de que desea eliminar la entrada?"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:58
-#: SettingsCenter@lauinger-clan.de/prefs.js:328
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
+#: SettingsCenter@lauinger-clan.de/prefs.js:116
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:59
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+msgid "SettingsCenter"
+msgstr "Centro de Configuraciones"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+#: SettingsCenter@lauinger-clan.de/prefs.js:311
+msgid "'Label' and 'Command' must be filled out !"
+msgstr "¡'Etiqueta' y 'Comando' deben ser completados!"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:113
+msgid "Delete entry"
+msgstr "Eliminar entrada"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:114
+msgid "Are you sure you want to delete the entry ?"
+msgstr "¿Está seguro de que desea eliminar la entrada?"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete"
 msgstr "Eliminar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:77
+#: SettingsCenter@lauinger-clan.de/prefs.js:132
 msgid "Up"
 msgstr "Arriba"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:147
 msgid "Down"
 msgstr "Abajo"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:165
 msgid "Del"
 msgstr "Eliminar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:146
+#: SettingsCenter@lauinger-clan.de/prefs.js:189
 msgid "Menu Items"
 msgstr "Elementos del menú"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:194
+#: SettingsCenter@lauinger-clan.de/prefs.js:228
+#: SettingsCenter@lauinger-clan.de/prefs.js:277
 msgid "Select app"
 msgstr "Seleccionar aplicación"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:205
+#: SettingsCenter@lauinger-clan.de/prefs.js:239
 msgid "Global"
 msgstr "Global"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:242
 msgid "Menu Label"
 msgstr "Etiqueta del menú"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:217
+#: SettingsCenter@lauinger-clan.de/prefs.js:247
 msgid "Apply"
 msgstr "Aplicar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:225
+#: SettingsCenter@lauinger-clan.de/prefs.js:255
 msgid "Show SystemIndicator"
 msgstr "Mostrar indicador del sistema"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:226
+#: SettingsCenter@lauinger-clan.de/prefs.js:256
 #: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:16
 msgid "Toggle to show systemindicator"
 msgstr "Alternar para mostrar el indicador del sistema"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:242
+#: SettingsCenter@lauinger-clan.de/prefs.js:262
 msgid "Add Menu"
 msgstr "Agregar menú"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:266
 msgid "Label"
 msgstr "Etiqueta"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:246
+#: SettingsCenter@lauinger-clan.de/prefs.js:267
 msgid "Label to show in menu"
 msgstr "Etiqueta para mostrar en el menú"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:270
 msgid "Command"
 msgstr "Comando"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:255
+#: SettingsCenter@lauinger-clan.de/prefs.js:271
 msgid "Name of .desktop file (MyApp.desktop) or name of command"
 msgstr "Nombre del archivo .desktop (MyApp.desktop) o nombre del comando"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:267
-msgid "Select desktop file"
-msgstr "Seleccionar archivo de escritorio"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:271
+#: SettingsCenter@lauinger-clan.de/prefs.js:280
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Generalmente ubicado en '/usr/share/applications'"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:285
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 msgid "Add"
 msgstr "Agregar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:290
+#: SettingsCenter@lauinger-clan.de/prefs.js:306
 msgid "Settings Center"
 msgstr "Centro de configuración"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:325
-msgid "Select"
-msgstr "Seleccionar"
 
 #: SettingsCenter@lauinger-clan.de/translation.js:7
 msgid "Gnome Tweaks"
@@ -174,6 +175,8 @@ msgstr "Elementos"
 msgid "Makes the systemindicator show/hide"
 msgstr "Hace que el indicador del sistema se muestre/oculte"
 
-#: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:21
-msgid "Last chosen file"
-msgstr "Último archivo elegido"
+#~ msgid "Select desktop file"
+#~ msgstr "Seleccionar archivo de escritorio"
+
+#~ msgid "Last chosen file"
+#~ msgstr "Último archivo elegido"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-09 00:47+0100\n"
+"POT-Creation-Date: 2025-07-26 12:36+0200\n"
 "PO-Revision-Date: 2025-02-09 18:55+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,117 +18,118 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: SettingsCenter@lauinger-clan.de/extension.js:64
-#: SettingsCenter@lauinger-clan.de/prefs.js:189
+#: SettingsCenter@lauinger-clan.de/extension.js:43
+#: SettingsCenter@lauinger-clan.de/prefs.js:223
 msgid "Settings"
 msgstr "Paramètres"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
-msgid "SettingsCenter"
-msgstr "Centre de paramètres"
+#: SettingsCenter@lauinger-clan.de/prefs.js:18
+msgid "Search..."
+msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:34
-#: SettingsCenter@lauinger-clan.de/prefs.js:298
-msgid "'Label' and 'Command' must be filled out !"
-msgstr "'Label' et 'Commande' doivent être remplis !"
+#: SettingsCenter@lauinger-clan.de/prefs.js:30
+msgid "Select"
+msgstr "Sélectionner"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:55
-msgid "Delete entry"
-msgstr "Supprimer l'entrée"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:56
-msgid "Are you sure you want to delete the entry ?"
-msgstr "Êtes-vous sûr de vouloir supprimer l'entrée ?"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:58
-#: SettingsCenter@lauinger-clan.de/prefs.js:328
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
+#: SettingsCenter@lauinger-clan.de/prefs.js:116
 msgid "Cancel"
 msgstr "Annuler"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:59
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+msgid "SettingsCenter"
+msgstr "Centre de paramètres"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+#: SettingsCenter@lauinger-clan.de/prefs.js:311
+msgid "'Label' and 'Command' must be filled out !"
+msgstr "'Label' et 'Commande' doivent être remplis !"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:113
+msgid "Delete entry"
+msgstr "Supprimer l'entrée"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:114
+msgid "Are you sure you want to delete the entry ?"
+msgstr "Êtes-vous sûr de vouloir supprimer l'entrée ?"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete"
 msgstr "Supprimer"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:77
+#: SettingsCenter@lauinger-clan.de/prefs.js:132
 msgid "Up"
 msgstr "Haut"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:147
 msgid "Down"
 msgstr "Bas"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:165
 msgid "Del"
 msgstr "Suppr"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:146
+#: SettingsCenter@lauinger-clan.de/prefs.js:189
 msgid "Menu Items"
 msgstr "Éléments du menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:194
+#: SettingsCenter@lauinger-clan.de/prefs.js:228
+#: SettingsCenter@lauinger-clan.de/prefs.js:277
 msgid "Select app"
 msgstr "Sélectionner l'application"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:205
+#: SettingsCenter@lauinger-clan.de/prefs.js:239
 msgid "Global"
 msgstr "Global"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:242
 msgid "Menu Label"
 msgstr "Étiquette du menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:217
+#: SettingsCenter@lauinger-clan.de/prefs.js:247
 msgid "Apply"
 msgstr "Appliquer"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:225
+#: SettingsCenter@lauinger-clan.de/prefs.js:255
 msgid "Show SystemIndicator"
 msgstr "Afficher l'indicateur système"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:226
+#: SettingsCenter@lauinger-clan.de/prefs.js:256
 #: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:16
 msgid "Toggle to show systemindicator"
 msgstr "Basculer pour afficher l'indicateur système"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:242
+#: SettingsCenter@lauinger-clan.de/prefs.js:262
 msgid "Add Menu"
 msgstr "Ajouter un menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:266
 msgid "Label"
 msgstr "Étiquette"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:246
+#: SettingsCenter@lauinger-clan.de/prefs.js:267
 msgid "Label to show in menu"
 msgstr "Étiquette à afficher dans le menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:270
 msgid "Command"
 msgstr "Commande"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:255
+#: SettingsCenter@lauinger-clan.de/prefs.js:271
 msgid "Name of .desktop file (MyApp.desktop) or name of command"
 msgstr "Nom du fichier .desktop (MonApp.desktop) ou nom de la commande"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:267
-msgid "Select desktop file"
-msgstr "Sélectionner le fichier .desktop"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:271
+#: SettingsCenter@lauinger-clan.de/prefs.js:280
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Généralement situé dans '/usr/share/applications'"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:285
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 msgid "Add"
 msgstr "Ajouter"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:290
+#: SettingsCenter@lauinger-clan.de/prefs.js:306
 msgid "Settings Center"
 msgstr "Centre de paramètres"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:325
-msgid "Select"
-msgstr "Sélectionner"
 
 #: SettingsCenter@lauinger-clan.de/translation.js:7
 msgid "Gnome Tweaks"
@@ -174,6 +175,8 @@ msgstr "Éléments"
 msgid "Makes the systemindicator show/hide"
 msgstr "Permet d'afficher/masquer l'indicateur système"
 
-#: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:21
-msgid "Last chosen file"
-msgstr "Dernier fichier choisi"
+#~ msgid "Select desktop file"
+#~ msgstr "Sélectionner le fichier .desktop"
+
+#~ msgid "Last chosen file"
+#~ msgstr "Dernier fichier choisi"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-09 00:47+0100\n"
+"POT-Creation-Date: 2025-07-26 12:36+0200\n"
 "PO-Revision-Date: 2024-03-08 16:54+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Dutch\n"
@@ -17,119 +17,120 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: SettingsCenter@lauinger-clan.de/extension.js:64
-#: SettingsCenter@lauinger-clan.de/prefs.js:189
+#: SettingsCenter@lauinger-clan.de/extension.js:43
+#: SettingsCenter@lauinger-clan.de/prefs.js:223
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
-msgid "SettingsCenter"
-msgstr "Voorkeurencentrum"
+#: SettingsCenter@lauinger-clan.de/prefs.js:18
+msgid "Search..."
+msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:34
-#: SettingsCenter@lauinger-clan.de/prefs.js:298
-msgid "'Label' and 'Command' must be filled out !"
-msgstr "Kies een label en opdracht !"
+#: SettingsCenter@lauinger-clan.de/prefs.js:30
+msgid "Select"
+msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:55
-msgid "Delete entry"
-msgstr "Verwijder invoer"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:56
-msgid "Are you sure you want to delete the entry ?"
-msgstr "Weet u zeker dat u de invoer wilt verwijderen?"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:58
-#: SettingsCenter@lauinger-clan.de/prefs.js:328
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
+#: SettingsCenter@lauinger-clan.de/prefs.js:116
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:59
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+msgid "SettingsCenter"
+msgstr "Voorkeurencentrum"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:93
+#: SettingsCenter@lauinger-clan.de/prefs.js:311
+msgid "'Label' and 'Command' must be filled out !"
+msgstr "Kies een label en opdracht !"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:113
+msgid "Delete entry"
+msgstr "Verwijder invoer"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:114
+msgid "Are you sure you want to delete the entry ?"
+msgstr "Weet u zeker dat u de invoer wilt verwijderen?"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:77
+#: SettingsCenter@lauinger-clan.de/prefs.js:132
 msgid "Up"
 msgstr "Omhoog"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:147
 msgid "Down"
 msgstr "Omlaag"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:165
 msgid "Del"
 msgstr "Del"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:146
+#: SettingsCenter@lauinger-clan.de/prefs.js:189
 msgid "Menu Items"
 msgstr "Menu-items"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:194
+#: SettingsCenter@lauinger-clan.de/prefs.js:228
+#: SettingsCenter@lauinger-clan.de/prefs.js:277
 msgid "Select app"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:205
+#: SettingsCenter@lauinger-clan.de/prefs.js:239
 msgid "Global"
 msgstr "Algemeen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:242
 msgid "Menu Label"
 msgstr "Menutekst"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:217
+#: SettingsCenter@lauinger-clan.de/prefs.js:247
 msgid "Apply"
 msgstr "Toepassen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:225
+#: SettingsCenter@lauinger-clan.de/prefs.js:255
 msgid "Show SystemIndicator"
 msgstr "Systeemindicator tonen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:226
+#: SettingsCenter@lauinger-clan.de/prefs.js:256
 #: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:16
 msgid "Toggle to show systemindicator"
 msgstr "Systeemindicator toon-/verbergknop"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:242
+#: SettingsCenter@lauinger-clan.de/prefs.js:262
 msgid "Add Menu"
 msgstr "Menu toevoegen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:266
 msgid "Label"
 msgstr "Tekst"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:246
+#: SettingsCenter@lauinger-clan.de/prefs.js:267
 msgid "Label to show in menu"
 msgstr "Het te tonen label in het menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:270
 msgid "Command"
 msgstr "Opdracht"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:255
+#: SettingsCenter@lauinger-clan.de/prefs.js:271
 msgid "Name of .desktop file (MyApp.desktop) or name of command"
 msgstr ""
 "De naam van een .desktopbestand (MijnToepassing.desktop) of naam van een "
 "opdracht"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:267
-msgid "Select desktop file"
-msgstr "Kies een .desktopbestand"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:271
+#: SettingsCenter@lauinger-clan.de/prefs.js:280
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Doorgaans te vinden in ‘/usr/share/applications’"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:285
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 msgid "Add"
 msgstr "Toevoegen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:290
+#: SettingsCenter@lauinger-clan.de/prefs.js:306
 msgid "Settings Center"
 msgstr "Voorkeurenmenu"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:325
-msgid "Select"
-msgstr ""
 
 #: SettingsCenter@lauinger-clan.de/translation.js:7
 msgid "Gnome Tweaks"
@@ -175,6 +176,8 @@ msgstr "Items"
 msgid "Makes the systemindicator show/hide"
 msgstr "Toon/Verberg de systeemindicator"
 
-#: SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml:21
-msgid "Last chosen file"
-msgstr "Laatst gekozen bestand"
+#~ msgid "Select desktop file"
+#~ msgstr "Kies een .desktopbestand"
+
+#~ msgid "Last chosen file"
+#~ msgstr "Laatst gekozen bestand"


### PR DESCRIPTION
Updates the extension to be compatible with GNOME Shell 49.

- Updates metadata to reflect compatibility with GNOME Shell 49.
- Replaces `console.error` and `console.log` calls with the extension's logger for better consistency and control over logging.