### PR TITLE
Updates metadata for Gnome 50 compatibility

### DIFF
--- a/SettingsCenter@lauinger-clan.de/metadata.json
+++ b/SettingsCenter@lauinger-clan.de/metadata.json
@@ -1,15 +1,16 @@
 {
+    "name": "SettingsCenter",
     "description": "Settings Center is a customizable drop-down menu for quickly launching frequently used apps in Gnome:Shell via the quicksettings. Originally created by XES.\n\nSettings shortcuts : gnome-tweak-tool, dconf-editor, gconf-editor, gnome-session-properties, gnome-shell-extension-prefs, seahorse and nvidia-settings. You can add your own\n\nOriginal source : http://svn.xesnet.fr/gnomeextensions",
     "gettext-domain": "SettingsCenter",
-    "name": "SettingsCenter",
-    "original-author": "Xes, l300lvl",
-    "shell-version": ["48", "49"],
-    "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SettingsCenter",
     "uuid": "SettingsCenter@lauinger-clan.de",
+    "shell-version": ["48", "49"],
+    "original-author": "Xes, l300lvl",
+    "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SettingsCenter",
     "settings-schema": "org.gnome.shell.extensions.SettingsCenter",
     "donations": {
         "github": "ChrisLauinger77",
         "paypal": "ChrisLauinger"
     },
-    "version-name": "49.4"
+    "version": 999,
+    "version-name": "50.0"
 }

--- a/SettingsCenter@lauinger-clan.de/metadata.json
+++ b/SettingsCenter@lauinger-clan.de/metadata.json
@@ -3,7 +3,7 @@
     "description": "Settings Center is a customizable drop-down menu for quickly launching frequently used apps in Gnome:Shell via the quicksettings. Originally created by XES.\n\nSettings shortcuts : gnome-tweak-tool, dconf-editor, gconf-editor, gnome-session-properties, gnome-shell-extension-prefs, seahorse and nvidia-settings. You can add your own\n\nOriginal source : http://svn.xesnet.fr/gnomeextensions",
     "gettext-domain": "SettingsCenter",
     "uuid": "SettingsCenter@lauinger-clan.de",
-    "shell-version": ["48", "49"],
+    "shell-version": ["48", "49", "50"],
     "original-author": "Xes, l300lvl",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-SettingsCenter",
     "settings-schema": "org.gnome.shell.extensions.SettingsCenter",

--- a/SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml
+++ b/SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml
@@ -7,7 +7,7 @@
       <description />
     </key>
     <key name="items" type="s">
-      <default>'Gnome Config Editor;gconf-editor.desktop;0;gconf-editor|Gnome Tweaks;org.gnome.tweaks.desktop;1;gnome-tweaks|Desktop Config Editor;ca.desrt.dconf-editor.desktop;1;dconf-editor|Extensions Preferences;org.gnome.Extensions.desktop;1;gnome-extensions-app|ExtensionManager;com.mattjakeman.ExtensionManager.desktop;0;com.mattjakeman.ExtensionManager|NVidia Settings;nvidia-settings.desktop;0;nvidia-settings|Passwords and Keys;org.gnome.seahorse.Application.desktop;1;seahorse|Volume Control;org.pulseaudio.pavucontrol.desktop;1;pavucontrol|Refine;page.tesk.Refine.desktop;0;page.tesk.Refine|Session Properties;session-properties.desktop;0;gnome-session-properties'</default>
+      <default>'Gdm Settings;io.github.realmazharhussain.GdmSettings.desktop;0;gdm-settings|Gnome Tweaks;org.gnome.tweaks.desktop;1;gnome-tweaks|Desktop Config Editor;ca.desrt.dconf-editor.desktop;1;dconf-editor|Extensions Preferences;org.gnome.Extensions.desktop;1;gnome-extensions-app|ExtensionManager;com.mattjakeman.ExtensionManager.desktop;0;com.mattjakeman.ExtensionManager|NVidia Settings;nvidia-settings.desktop;0;nvidia-settings|Passwords and Keys;org.gnome.seahorse.Application.desktop;1;seahorse|Volume Control;org.pulseaudio.pavucontrol.desktop;1;pavucontrol|Refine;page.tesk.Refine.desktop;0;page.tesk.Refine|Session Properties;session-properties.desktop;0;gnome-session-properties'</default>
       <summary>Items</summary>
       <description />
     </key>

--- a/po/SettingsCenter.pot
+++ b/po/SettingsCenter.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 15:25+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,19 +84,19 @@ msgstr ""
 msgid "Enable/Disable item"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:195
+#: SettingsCenter@lauinger-clan.de/prefs.js:208
 msgid "Menu Items"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:239
+#: SettingsCenter@lauinger-clan.de/prefs.js:253
 msgid "Reset Settings"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:259
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:286
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 15:25+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 15:26+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -85,19 +85,19 @@ msgstr "Element löschen"
 msgid "Enable/Disable item"
 msgstr "Element aktivieren/deaktivieren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:195
+#: SettingsCenter@lauinger-clan.de/prefs.js:208
 msgid "Menu Items"
 msgstr "Menü Einträge"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:239
+#: SettingsCenter@lauinger-clan.de/prefs.js:253
 msgid "Reset Settings"
 msgstr "Einstellungen zurücksetzen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:259
 msgid "Reset all settings to default values"
 msgstr "Alle Einstellungen auf Standardwerte zurücksetzen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:286
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 15:25+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 15:20+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -85,19 +85,19 @@ msgstr ""
 msgid "Enable/Disable item"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:195
+#: SettingsCenter@lauinger-clan.de/prefs.js:208
 msgid "Menu Items"
 msgstr "Elementos del menú"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:239
+#: SettingsCenter@lauinger-clan.de/prefs.js:253
 msgid "Reset Settings"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:259
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:286
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 15:25+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 12:58+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -85,19 +85,19 @@ msgstr ""
 msgid "Enable/Disable item"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:195
+#: SettingsCenter@lauinger-clan.de/prefs.js:208
 msgid "Menu Items"
 msgstr "Éléments du menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:239
+#: SettingsCenter@lauinger-clan.de/prefs.js:253
 msgid "Reset Settings"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:259
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:286
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-01 15:25+0100\n"
+"POT-Creation-Date: 2026-02-07 09:57+0100\n"
 "PO-Revision-Date: 2026-01-01 13:00+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Dutch\n"
@@ -84,19 +84,19 @@ msgstr ""
 msgid "Enable/Disable item"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:195
+#: SettingsCenter@lauinger-clan.de/prefs.js:208
 msgid "Menu Items"
 msgstr "Menu-items"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:239
+#: SettingsCenter@lauinger-clan.de/prefs.js:253
 msgid "Reset Settings"
 msgstr "Instellingen resetten"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:245
+#: SettingsCenter@lauinger-clan.de/prefs.js:259
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:286
+#: SettingsCenter@lauinger-clan.de/prefs.js:300
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"


### PR DESCRIPTION
Updates the extension metadata to ensure compatibility with Gnome 50.
This includes adjusting the shell-version and version-name.
