### PR TITLE
Add drag-and-drop reorder for menu items in prefs.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Project
+
+SettingsCenter is a GNOME Shell extension that adds a customizable quick settings menu for launching settings tools and apps.
+
+The extension UUID is `SettingsCenter@lauinger-clan.de`.
+
+Current target shell versions are declared in `SettingsCenter@lauinger-clan.de/metadata.json`. Keep compatibility with all declared versions unless the user explicitly changes the target.
+
+## Repository Map
+
+- `SettingsCenter@lauinger-clan.de/extension.js`: GNOME Shell runtime code. Builds the quick settings indicator and launches configured items.
+- `SettingsCenter@lauinger-clan.de/prefs.js`: libadwaita/GTK preferences window. Manages label, system indicator toggle, app chooser, item add/delete/enable/reorder UI.
+- `SettingsCenter@lauinger-clan.de/lib/menu_items.js`: GSettings-backed menu item model and serialization helpers.
+- `SettingsCenter@lauinger-clan.de/schemas/org.gnome.shell.extensions.SettingsCenter.gschema.xml`: GSettings schema and default menu item string.
+- `SettingsCenter@lauinger-clan.de/ui/prefs.ui`: GtkBuilder UI for static preferences pages.
+- `po/`: translations.
+- `settingscenter.sh`: helper script for pack/install/upload/translation updates.
+- `eslint.config.js`: ESLint 9 flat config.
+
+## Development Notes
+
+- This is GJS ES module code. Prefer GNOME/GJS APIs and existing local patterns.
+- Runtime Shell code may use GNOME Shell private modules. Check compatibility carefully across every shell version listed in `metadata.json`.
+- Preferences code uses GTK4/libadwaita and should avoid Shell-only APIs.
+- For GI imports where multiple major versions can exist, prefer explicit versions when practical, for example `gi://Gdk?version=4.0`.
+- Preserve user changes. The worktree may contain staged or unstaged edits unrelated to your task.
+
+## Menu Item Storage
+
+Menu items are stored in GSettings key `items` as a single serialized string:
+
+```text
+label;cmd;enable;cmd-alt|label;cmd;enable;cmd-alt
+```
+
+Be careful with parsing and writing this format. Labels or commands containing `;` or `|` will currently break the format.
+
+## Validation
+
+Useful checks:
+
+```sh
+node --check SettingsCenter@lauinger-clan.de/prefs.js
+node --check SettingsCenter@lauinger-clan.de/extension.js
+npm run lint
+```
+
+`npm run lint` requires ESLint 9. If the system picks up ESLint 6, install/use the project dependencies before trusting lint output.
+
+Packaging and install helpers:
+
+```sh
+./settingscenter.sh pack
+./settingscenter.sh install
+./settingscenter.sh translate
+```
+
+Do not upload releases unless the user explicitly asks.
+
+## Translations
+
+If a change adds, removes, or edits user-visible strings wrapped for translation, remind the user to run:
+
+```sh
+./settingscenter.sh translate
+```
+
+Do not update translations automatically unless the user asks, because it may touch many `po/` files.
+
+## Testing Checklist
+
+For preferences changes:
+
+- Open the preferences window without console errors.
+- Add a `.desktop` app through the app chooser.
+- Add a plain command manually.
+- Enable/disable an item.
+- Delete an item.
+- Reorder items and reopen preferences to confirm persistence.
+- Confirm the quick settings menu reflects the saved order and enabled state.
+
+For runtime extension changes:
+
+- Enable and disable the extension cleanly.
+- Toggle `show-systemindicator`.
+- Change `label-menu` and confirm the quick settings UI updates.
+- Launch both `.desktop` items and command items.
+
+When compatibility matters, test on every GNOME Shell version declared in `metadata.json`.
+
+## Common Gotchas
+
+- `.desktop` matching should use an escaped dot, for example `/\.desktop$/`.
+- Bounds checks should reject indexes with `index < 0 || index >= items.length`.
+- Avoid assuming `_settings`, `_settingSignals`, or `_indicator` are initialized during teardown unless the code guarantees it.

--- a/SettingsCenter@lauinger-clan.de/metadata.json
+++ b/SettingsCenter@lauinger-clan.de/metadata.json
@@ -13,5 +13,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.1"
+    "version-name": "50.2"
 }

--- a/SettingsCenter@lauinger-clan.de/prefs.js
+++ b/SettingsCenter@lauinger-clan.de/prefs.js
@@ -2,6 +2,7 @@
 
 import Gtk from "gi://Gtk";
 import Gio from "gi://Gio";
+import Gdk from "gi://Gdk";
 import Adw from "gi://Adw";
 import GObject from "gi://GObject";
 import * as Menu_Items from "./lib/menu_items.js";
@@ -103,10 +104,32 @@ export default class AdwPrefs extends ExtensionPreferences {
         this._buildList(menuItems, page2);
     }
 
-    _changeOrder(menuItems, page2, index, order) {
-        menuItems.changeOrder(index, order);
+    _moveItem(menuItems, page2, fromIndex, toIndex) {
+        if (fromIndex === toIndex) return;
 
+        menuItems.changeOrder(fromIndex, toIndex - fromIndex);
         this._buildList(menuItems, page2);
+    }
+
+    _loadStylesheet() {
+        if (this._stylesheetLoaded) return;
+
+        const display = Gdk.Display.get_default();
+        if (display === null) return;
+
+        const provider = new Gtk.CssProvider();
+        provider.load_from_path(`${this.path}/stylesheet.css`);
+        Gtk.StyleContext.add_provider_for_display(
+            display,
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
+        this._stylesheetLoaded = true;
+    }
+
+    _dragHighlightRow(adwrow, active) {
+        if (active) adwrow.add_css_class("drag_highlight_row");
+        else adwrow.remove_css_class("drag_highlight_row");
     }
 
     _delCmd(menuItems, page2, index) {
@@ -127,38 +150,6 @@ export default class AdwPrefs extends ExtensionPreferences {
         });
 
         dialog.present();
-    }
-
-    _buttonUp(menuItems, page2, indexItem) {
-        const buttonUp = new Gtk.Button({
-            label: _("Up"),
-            valign: Gtk.Align.CENTER,
-        });
-        buttonUp.set_icon_name("go-up-symbolic");
-        buttonUp.set_tooltip_text(_("Move item up"));
-        if (indexItem > 0) {
-            buttonUp.connect("clicked", this._changeOrder.bind(this, menuItems, page2, indexItem, -1));
-            buttonUp.set_sensitive(true);
-        } else {
-            buttonUp.set_sensitive(false);
-        }
-        return buttonUp;
-    }
-
-    _buttonDown(menuItems, page2, indexItem, itemslen) {
-        const buttonDown = new Gtk.Button({
-            label: _("Down"),
-            valign: Gtk.Align.CENTER,
-        });
-        buttonDown.set_icon_name("go-down-symbolic");
-        buttonDown.set_tooltip_text(_("Move item down"));
-        if (indexItem < itemslen - 1) {
-            buttonDown.connect("clicked", this._changeOrder.bind(this, menuItems, page2, indexItem, 1));
-            buttonDown.set_sensitive(true);
-        } else {
-            buttonDown.set_sensitive(false);
-        }
-        return buttonDown;
     }
 
     _buttonDel(menuItems, page2, indexItem, itemslen) {
@@ -200,12 +191,55 @@ export default class AdwPrefs extends ExtensionPreferences {
         }
     }
 
+    _dragHandle(indexItem) {
+        const dragHandle = new Gtk.Image({
+            icon_name: "list-drag-handle-symbolic",
+            css_classes: ["dim-label"],
+        });
+        dragHandle.set_tooltip_text(_("Drag to reorder"));
+
+        const dragSource = new Gtk.DragSource({
+            actions: Gdk.DragAction.MOVE,
+        });
+        dragSource.connect("prepare", () => Gdk.ContentProvider.new_for_value(String(indexItem)));
+        dragHandle.add_controller(dragSource);
+
+        return dragHandle;
+    }
+
+    _makeRowDropTarget(adwrow, menuItems, page2, indexItem) {
+        const dropTarget = Gtk.DropTarget.new(GObject.TYPE_STRING, Gdk.DragAction.MOVE);
+        dropTarget.connect("enter", () => {
+            this._dragHighlightRow(adwrow, true);
+            return Gdk.DragAction.MOVE;
+        });
+        dropTarget.connect("leave", () => {
+            this._dragHighlightRow(adwrow, false);
+        });
+        dropTarget.connect("drop", (_target, value, _x, y) => {
+            this._dragHighlightRow(adwrow, false);
+            const fromIndex = Number.parseInt(value, 10);
+            const rowIndex = Number.parseInt(indexItem, 10);
+
+            if (Number.isNaN(fromIndex) || Number.isNaN(rowIndex)) return false;
+
+            let toIndex = rowIndex;
+            if (y > adwrow.get_height() / 2) toIndex += 1;
+            if (fromIndex < toIndex) toIndex -= 1;
+
+            this._moveItem(menuItems, page2, fromIndex, toIndex);
+            return true;
+        });
+        adwrow.add_controller(dropTarget);
+    }
+
     _buildList(menuItems, page2) {
         if (page2._group3 !== null) {
             page2.remove(page2._group3);
         }
         const group3 = Adw.PreferencesGroup.new();
         group3.set_title(_("Menu Items"));
+        group3.set_description(_("Add custom commands to the menu, rows can be reordered by drag and drop."));
         group3.set_name("settingscenter_menuitems");
         page2.add(group3);
         page2._group3 = group3;
@@ -221,21 +255,14 @@ export default class AdwPrefs extends ExtensionPreferences {
             adwrow.set_tooltip_text(item["cmd"]);
             this._addAppIcon(adwrow, item["cmd"]);
             group3.add(adwrow);
-            const buttonUp = this._buttonUp(menuItems, page2, indexItem);
-            const buttonDown = this._buttonDown(menuItems, page2, indexItem, items.length);
             const valueList = this._valueList(menuItems, indexItem, item);
             const buttonDel = this._buttonDel(menuItems, page2, indexItem, items.length);
+            adwrow.add_prefix(this._dragHandle(indexItem));
+            this._makeRowDropTarget(adwrow, menuItems, page2, indexItem);
             adwrow.add_suffix(valueList);
             adwrow.activatable_widget = valueList;
-            adwrow.add_suffix(buttonUp);
-            adwrow.add_suffix(buttonDown);
             if (buttonDel !== null) adwrow.add_suffix(buttonDel);
         }
-    }
-
-    _getFilename(fullPath) {
-        this.getLogger().log("_getFilename fullPath: " + fullPath);
-        return fullPath.replace(/^.*[\\/]/, "");
     }
 
     _findWidgetByType(parent, type) {
@@ -288,6 +315,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         let adwrow;
         const builder = Gtk.Builder.new();
         builder.add_from_file(this.path + "/ui/prefs.ui");
+        this._loadStylesheet();
         const page1 = builder.get_object("SettingsCenter_page_settings");
         const page2 = builder.get_object("SettingsCenter_page_menuitems");
         const buttonMenu = builder.get_object("SettingsCenter_row_buttonmenulabel");

--- a/SettingsCenter@lauinger-clan.de/stylesheet.css
+++ b/SettingsCenter@lauinger-clan.de/stylesheet.css
@@ -1,0 +1,4 @@
+.drag_highlight_row {
+    background-color: alpha(@accent_bg_color, 0.14);
+    box-shadow: inset 0 0 0 1px alpha(@accent_bg_color, 0.55);
+}

--- a/po/SettingsCenter.pot
+++ b/po/SettingsCenter.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-07 09:57+0100\n"
+"POT-Creation-Date: 2026-05-23 11:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,81 +22,74 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:20
+#: SettingsCenter@lauinger-clan.de/prefs.js:21
 msgid "Search..."
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
 msgid "Select"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:35
-#: SettingsCenter@lauinger-clan.de/prefs.js:118
+#: SettingsCenter@lauinger-clan.de/prefs.js:36
+#: SettingsCenter@lauinger-clan.de/prefs.js:120
 msgid "Cancel"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 msgid "SettingsCenter"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:57
 msgid "'Label' and 'Command' must be filled out !"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:115
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete entry"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:118
 msgid "Are you sure you want to delete the entry ?"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:119
+#: SettingsCenter@lauinger-clan.de/prefs.js:121
 msgid "Delete"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:134
-msgid "Up"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:138
-msgid "Move item up"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:150
-msgid "Down"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:154
-msgid "Move item down"
-msgstr ""
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:169
+#: SettingsCenter@lauinger-clan.de/prefs.js:139
 msgid "Del"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:174
+#: SettingsCenter@lauinger-clan.de/prefs.js:144
 msgid "Delete item"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:185
+#: SettingsCenter@lauinger-clan.de/prefs.js:155
 msgid "Enable/Disable item"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:178
+msgid "Drag to reorder"
+msgstr ""
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:212
 msgid "Menu Items"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:213
+msgid ""
+"Add custom commands to the menu, rows can be reordered by drag and drop."
+msgstr ""
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:251
 msgid "Reset Settings"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:259
+#: SettingsCenter@lauinger-clan.de/prefs.js:257
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:300
+#: SettingsCenter@lauinger-clan.de/prefs.js:298
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-07 09:57+0100\n"
-"PO-Revision-Date: 2026-01-01 15:26+0100\n"
+"POT-Creation-Date: 2026-05-23 11:55+0200\n"
+"PO-Revision-Date: 2026-05-23 11:56+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -23,81 +23,76 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:20
+#: SettingsCenter@lauinger-clan.de/prefs.js:21
 msgid "Search..."
 msgstr "Suchen..."
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
 msgid "Select"
 msgstr "Auswählen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:35
-#: SettingsCenter@lauinger-clan.de/prefs.js:118
+#: SettingsCenter@lauinger-clan.de/prefs.js:36
+#: SettingsCenter@lauinger-clan.de/prefs.js:120
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 msgid "SettingsCenter"
 msgstr "Einstellungszentrum"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:57
 msgid "'Label' and 'Command' must be filled out !"
 msgstr "'Beschriftung' und 'Kommando' müssen ausgefüllt werden !"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:115
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete entry"
 msgstr "Eintrag löschen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:118
 msgid "Are you sure you want to delete the entry ?"
 msgstr "Sind Sie sicher das Sie den Eintrag löschen möchten ?"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:119
+#: SettingsCenter@lauinger-clan.de/prefs.js:121
 msgid "Delete"
 msgstr "Löschen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:134
-msgid "Up"
-msgstr "Auf"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:138
-msgid "Move item up"
-msgstr "Element nach oben verschieben"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:150
-msgid "Down"
-msgstr "Ab"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:154
-msgid "Move item down"
-msgstr "Element nach unten verschieben"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:169
+#: SettingsCenter@lauinger-clan.de/prefs.js:139
 msgid "Del"
 msgstr "Entf"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:174
+#: SettingsCenter@lauinger-clan.de/prefs.js:144
 msgid "Delete item"
 msgstr "Element löschen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:185
+#: SettingsCenter@lauinger-clan.de/prefs.js:155
 msgid "Enable/Disable item"
 msgstr "Element aktivieren/deaktivieren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:178
+msgid "Drag to reorder"
+msgstr "Zum Neuanordnen ziehen"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:212
 msgid "Menu Items"
 msgstr "Menü Einträge"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:213
+msgid ""
+"Add custom commands to the menu, rows can be reordered by drag and drop."
+msgstr ""
+"Fügen Sie dem Menü benutzerdefinierte Befehle hinzu; die Zeilen können per "
+"Drag & Drop neu angeordnet werden."
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:251
 msgid "Reset Settings"
 msgstr "Einstellungen zurücksetzen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:259
+#: SettingsCenter@lauinger-clan.de/prefs.js:257
 msgid "Reset all settings to default values"
 msgstr "Alle Einstellungen auf Standardwerte zurücksetzen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:300
+#: SettingsCenter@lauinger-clan.de/prefs.js:298
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/es.po
+++ b/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-07 09:57+0100\n"
-"PO-Revision-Date: 2026-01-01 15:20+0100\n"
+"POT-Creation-Date: 2026-05-23 11:55+0200\n"
+"PO-Revision-Date: 2026-05-23 11:53+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -22,81 +22,76 @@ msgstr ""
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:20
+#: SettingsCenter@lauinger-clan.de/prefs.js:21
 msgid "Search..."
 msgstr "Buscar..."
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
 msgid "Select"
 msgstr "Seleccionar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:35
-#: SettingsCenter@lauinger-clan.de/prefs.js:118
+#: SettingsCenter@lauinger-clan.de/prefs.js:36
+#: SettingsCenter@lauinger-clan.de/prefs.js:120
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 msgid "SettingsCenter"
 msgstr "Centro de Configuraciones"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:57
 msgid "'Label' and 'Command' must be filled out !"
 msgstr "¡'Etiqueta' y 'Comando' deben ser completados!"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:115
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete entry"
 msgstr "Eliminar entrada"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:118
 msgid "Are you sure you want to delete the entry ?"
 msgstr "¿Está seguro de que desea eliminar la entrada?"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:119
+#: SettingsCenter@lauinger-clan.de/prefs.js:121
 msgid "Delete"
 msgstr "Eliminar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:134
-msgid "Up"
-msgstr "Arriba"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:138
-msgid "Move item up"
-msgstr "Mover elemento hacia arriba"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:150
-msgid "Down"
-msgstr "Abajo"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:154
-msgid "Move item down"
-msgstr "Mover elemento hacia abajo"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:169
+#: SettingsCenter@lauinger-clan.de/prefs.js:139
 msgid "Del"
 msgstr "Eliminar"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:174
+#: SettingsCenter@lauinger-clan.de/prefs.js:144
 msgid "Delete item"
 msgstr "Eliminar elemento"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:185
+#: SettingsCenter@lauinger-clan.de/prefs.js:155
 msgid "Enable/Disable item"
 msgstr "Activar/desactivar elemento"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:178
+msgid "Drag to reorder"
+msgstr "Arrastrar para reordenar"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:212
 msgid "Menu Items"
 msgstr "Elementos del menú"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:213
+msgid ""
+"Add custom commands to the menu, rows can be reordered by drag and drop."
+msgstr ""
+"Añada comandos personalizados al menú; las filas se pueden reordenar "
+"arrastrando y soltando."
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:251
 msgid "Reset Settings"
 msgstr "Restablecer configuración"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:259
+#: SettingsCenter@lauinger-clan.de/prefs.js:257
 msgid "Reset all settings to default values"
 msgstr "Restablecer todos los ajustes a sus valores predeterminados"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:300
+#: SettingsCenter@lauinger-clan.de/prefs.js:298
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-07 09:57+0100\n"
-"PO-Revision-Date: 2026-01-01 12:58+0100\n"
+"POT-Creation-Date: 2026-05-23 11:55+0200\n"
+"PO-Revision-Date: 2026-05-23 11:53+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: fr\n"
@@ -22,81 +22,76 @@ msgstr ""
 msgid "Settings"
 msgstr "Paramètres"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:20
+#: SettingsCenter@lauinger-clan.de/prefs.js:21
 msgid "Search..."
 msgstr "Rechercher..."
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
 msgid "Select"
 msgstr "Sélectionner"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:35
-#: SettingsCenter@lauinger-clan.de/prefs.js:118
+#: SettingsCenter@lauinger-clan.de/prefs.js:36
+#: SettingsCenter@lauinger-clan.de/prefs.js:120
 msgid "Cancel"
 msgstr "Annuler"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 msgid "SettingsCenter"
 msgstr "Centre de paramètres"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:57
 msgid "'Label' and 'Command' must be filled out !"
 msgstr "'Label' et 'Commande' doivent être remplis !"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:115
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete entry"
 msgstr "Supprimer l'entrée"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:118
 msgid "Are you sure you want to delete the entry ?"
 msgstr "Êtes-vous sûr de vouloir supprimer l'entrée ?"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:119
+#: SettingsCenter@lauinger-clan.de/prefs.js:121
 msgid "Delete"
 msgstr "Supprimer"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:134
-msgid "Up"
-msgstr "Haut"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:138
-msgid "Move item up"
-msgstr "Déplacer l'élément vers le haut"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:150
-msgid "Down"
-msgstr "Bas"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:154
-msgid "Move item down"
-msgstr "Déplacer l'élément vers le bas"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:169
+#: SettingsCenter@lauinger-clan.de/prefs.js:139
 msgid "Del"
 msgstr "Suppr"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:174
+#: SettingsCenter@lauinger-clan.de/prefs.js:144
 msgid "Delete item"
 msgstr "Supprimer l'élément"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:185
+#: SettingsCenter@lauinger-clan.de/prefs.js:155
 msgid "Enable/Disable item"
 msgstr "Activer/désactiver l'élément"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:178
+msgid "Drag to reorder"
+msgstr "Faire glisser pour réordonner"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:212
 msgid "Menu Items"
 msgstr "Éléments du menu"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:213
+msgid ""
+"Add custom commands to the menu, rows can be reordered by drag and drop."
+msgstr ""
+"Ajoutez des commandes personnalisées au menu ; les lignes peuvent être "
+"réordonnées par glisser-déposer."
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:251
 msgid "Reset Settings"
 msgstr "Réinitialiser les paramètres"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:259
+#: SettingsCenter@lauinger-clan.de/prefs.js:257
 msgid "Reset all settings to default values"
 msgstr "Réinitialiser tous les paramètres aux valeurs par défaut"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:300
+#: SettingsCenter@lauinger-clan.de/prefs.js:298
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-07 09:57+0100\n"
-"PO-Revision-Date: 2026-01-01 13:00+0100\n"
+"POT-Creation-Date: 2026-05-23 11:55+0200\n"
+"PO-Revision-Date: 2026-05-23 11:53+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Dutch\n"
 "Language: nl\n"
@@ -22,81 +22,76 @@ msgstr ""
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:20
+#: SettingsCenter@lauinger-clan.de/prefs.js:21
 msgid "Search..."
 msgstr "Zoeken..."
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:32
+#: SettingsCenter@lauinger-clan.de/prefs.js:33
 msgid "Select"
 msgstr "Selecteren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:35
-#: SettingsCenter@lauinger-clan.de/prefs.js:118
+#: SettingsCenter@lauinger-clan.de/prefs.js:36
+#: SettingsCenter@lauinger-clan.de/prefs.js:120
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 msgid "SettingsCenter"
 msgstr "Voorkeurencentrum"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:95
+#: SettingsCenter@lauinger-clan.de/prefs.js:96
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:57
 msgid "'Label' and 'Command' must be filled out !"
 msgstr "Kies een label en opdracht !"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:115
+#: SettingsCenter@lauinger-clan.de/prefs.js:117
 msgid "Delete entry"
 msgstr "Verwijder invoer"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:116
+#: SettingsCenter@lauinger-clan.de/prefs.js:118
 msgid "Are you sure you want to delete the entry ?"
 msgstr "Weet u zeker dat u de invoer wilt verwijderen?"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:119
+#: SettingsCenter@lauinger-clan.de/prefs.js:121
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:134
-msgid "Up"
-msgstr "Omhoog"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:138
-msgid "Move item up"
-msgstr "Item omhoog verplaatsen"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:150
-msgid "Down"
-msgstr "Omlaag"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:154
-msgid "Move item down"
-msgstr "Item omlaag verplaatsen"
-
-#: SettingsCenter@lauinger-clan.de/prefs.js:169
+#: SettingsCenter@lauinger-clan.de/prefs.js:139
 msgid "Del"
 msgstr "Del"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:174
+#: SettingsCenter@lauinger-clan.de/prefs.js:144
 msgid "Delete item"
 msgstr "Item verwijderen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:185
+#: SettingsCenter@lauinger-clan.de/prefs.js:155
 msgid "Enable/Disable item"
 msgstr "Item in-/uitschakelen"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:208
+#: SettingsCenter@lauinger-clan.de/prefs.js:178
+msgid "Drag to reorder"
+msgstr "Sleep om te herschikken"
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:212
 msgid "Menu Items"
 msgstr "Menu-items"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:253
+#: SettingsCenter@lauinger-clan.de/prefs.js:213
+msgid ""
+"Add custom commands to the menu, rows can be reordered by drag and drop."
+msgstr ""
+"Voeg aangepaste opdrachten toe aan het menu; rijen kunnen met slepen en "
+"neerzetten worden herschikt."
+
+#: SettingsCenter@lauinger-clan.de/prefs.js:251
 msgid "Reset Settings"
 msgstr "Instellingen resetten"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:259
+#: SettingsCenter@lauinger-clan.de/prefs.js:257
 msgid "Reset all settings to default values"
 msgstr "Alle instellingen terugzetten naar standaardwaarden"
 
-#: SettingsCenter@lauinger-clan.de/prefs.js:300
+#: SettingsCenter@lauinger-clan.de/prefs.js:298
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:38
 #: SettingsCenter@lauinger-clan.de/ui/prefs.ui:39
 msgid "Select app"


### PR DESCRIPTION
Replaces up/down buttons with a drag-and-drop functionality to reorder menu items in the preferences window, enhancing user experience. Updates relevant translations and bumps version name to 50.2.
