### PR TITLE
Add install-dependencies helper command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,13 @@ Current target shell versions are declared in `SettingsCenter@lauinger-clan.de/m
 - Preserve user changes. The worktree may contain staged or unstaged edits unrelated to your task.
 - Use `$review-gnome-shell-extension` before changing runtime, preferences, metadata, schema, packaging, or user-data behavior that may affect extensions.gnome.org review.
 
+## Useful Commands
+
+- `./settingscenter.sh install-dependencies`: install the locked JavaScript dependencies.
+
+Run `./settingscenter.sh install-dependencies` after pulling or rebasing remote
+changes that modify `package-lock.json`, particularly Renovate updates.
+
 ## Menu Item Storage
 
 Menu items are stored in GSettings key `items` as a single serialized string:

--- a/settingscenter.sh
+++ b/settingscenter.sh
@@ -13,6 +13,9 @@ source "$script_dir/.githooks/version-actions.sh"
 echo "Running $0 for $extension with arguments: $@"
 
 case "${1:-}" in
+  install-dependencies)
+    npm ci
+    ;;
   cleanup)
     if [[ -f "$extensionfile" ]]; then
       rm -- "$extensionfile"
@@ -68,7 +71,7 @@ case "${1:-}" in
     echo "Done."
     ;;
   *)
-    echo "Usage: $0 {zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
+    echo "Usage: $0 {install-dependencies|zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- add an `install-dependencies` command to the repository helper that runs `npm ci` from the repository root
- include the command in the helper usage output
- document running the command after lockfile changes, particularly Renovate updates

## Validation

- helper shell syntax check
- `install-dependencies` command
- `npm run lint`
- helper usage output
- generated artifact scan
